### PR TITLE
Fix/make custom config optional

### DIFF
--- a/addon/initializers/rdfa-toc-plugin.js
+++ b/addon/initializers/rdfa-toc-plugin.js
@@ -1,4 +1,4 @@
-import RdfaTocSamplePlugin from '../rdfa-toc-sample-plugin';
+import RdfaTocPlugin from '../rdfa-toc-plugin';
 
 function pluginFactory(plugin) {
   return {
@@ -11,7 +11,7 @@ function pluginFactory(plugin) {
 }
 
 export function initialize(application) {
-  application.register('plugin:rdfa-toc', pluginFactory(RdfaTocSamplePlugin), {
+  application.register('plugin:rdfa-toc', pluginFactory(RdfaTocPlugin), {
     singleton: false,
   });
 }

--- a/addon/rdfa-toc-plugin.js
+++ b/addon/rdfa-toc-plugin.js
@@ -1,10 +1,10 @@
 import TableOfContentsSpec from './models/inline-components/table-of-contents';
 
-export default class RdfaTocSamplePlugin {
+export default class RdfaTocPlugin {
   controller;
 
   get name() {
-    return 'rdfa-ic-sample';
+    return 'rdfa-toc';
   }
 
   initialize(controller, options) {

--- a/addon/rdfa-toc-plugin.js
+++ b/addon/rdfa-toc-plugin.js
@@ -12,13 +12,16 @@ export default class RdfaTocPlugin {
     controller.registerInlineComponent(
       new TableOfContentsSpec(this.controller)
     );
+    const widgetArgs = options?.config
+      ? {
+          config: options.config,
+        }
+      : {};
     controller.registerWidget({
       componentName: 'table-of-contents-card',
       identifier: 'table-of-contents-plugin/card',
       desiredLocation: 'sidebar',
-      widgetArgs: {
-        config: options.config,
-      },
+      widgetArgs,
     });
   }
 }

--- a/app/initializers/rdfa-toc-plugin.js
+++ b/app/initializers/rdfa-toc-plugin.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  initialize,
+} from '@lblod/ember-rdfa-editor-table-of-contents-plugin/initializers/rdfa-toc-plugin';

--- a/app/initializers/rdfa-toc-sample-plugin.js
+++ b/app/initializers/rdfa-toc-sample-plugin.js
@@ -1,4 +1,0 @@
-export {
-  default,
-  initialize,
-} from '@lblod/ember-rdfa-editor-table-of-contents-plugin/initializers/rdfa-toc-sample-plugin';

--- a/app/rdfa-toc-plugin.js
+++ b/app/rdfa-toc-plugin.js
@@ -1,0 +1,1 @@
+export { default } from 'rdfa-toc-plugin';

--- a/app/rdfa-toc-sample-plugin.js
+++ b/app/rdfa-toc-sample-plugin.js
@@ -1,1 +1,0 @@
-export { default } from 'rdfa-toc-sample-plugin';

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 export default class ApplicationController extends Controller {
   plugins = [
+    // 'rdfa-toc',
     { name: 'rdfa-toc', options: { config: this.tableOfContentsConfig } },
     'article-structure',
   ];


### PR DESCRIPTION
Before when trying to initialize the plugin without any configuration, the application would throw an error. This fix makes passing the config to the plugin optional.