### PR TITLE
Fix for tracked `toggled` property

### DIFF
--- a/addon/components/table-of-contents-card.js
+++ b/addon/components/table-of-contents-card.js
@@ -1,15 +1,22 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class TableOfContentsCardComponent extends Component {
+  @tracked toggled;
+
+  constructor() {
+    super(...arguments);
+    this.toggled = this.tableOfContentsInstances.length !== 0;
+    this.args.controller.onEvent('modelWritten', () => {
+      this.toggled = this.tableOfContentsInstances.length !== 0;
+    });
+  }
+
   get tableOfContentsInstances() {
     return this.args.controller.getComponentInstances({
       componentName: 'inline-components/table-of-contents',
     });
-  }
-
-  get toggled() {
-    return this.tableOfContentsInstances.length !== 0;
   }
 
   get tableOfContentsProps() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@ember/test-helpers": "^2.6.0",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
-        "@lblod/ember-rdfa-editor": ">=0.63.1",
+        "@lblod/ember-rdfa-editor": "github:lblod/ember-rdfa-editor#fix/inline-components-management",
         "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.2.9",
         "@types/ember": "^4.0.0",
         "@types/ember__application": "^4.0.0",
@@ -95,7 +95,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^1.5.0",
-        "@lblod/ember-rdfa-editor": ">=0.62.1",
+        "@lblod/ember-rdfa-editor": ">=0.63.1",
         "ember-concurrency": "^2.0.0"
       }
     },
@@ -3626,15 +3626,15 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.63.1.tgz",
-      "integrity": "sha512-s51CSJcdE0xlImI+PQsDBLSIyTpOJP3pE3yed5lfoT1+UkGtGFi2TtkRqUjzrCdlk/pHz/GG/X+nT1JgGeyLtw==",
+      "version": "0.63.2",
+      "resolved": "git+ssh://git@github.com/lblod/ember-rdfa-editor.git#e5d71f58dbb684e73aed2cbe45c02973c2b5ee6f",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",
         "@codemirror/lang-xml": "^6.0.0",
         "@codemirror/state": "^6.1.1",
-        "@codemirror/view": "github:codemirror/view#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
+        "@codemirror/view": "^6.2.3",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
         "@glimmer/tracking": "^1.0.4",
@@ -3667,7 +3667,7 @@
         "rdf-data-factory": "^1.1.0",
         "relative-to-absolute-iri": "^1.0.6",
         "stream-browserify": "^3.0.0",
-        "tracked-built-ins": "^2.0.1",
+        "tracked-built-ins": "^3.1.0",
         "xml-formatter": "^2.6.1"
       },
       "engines": {
@@ -3806,11 +3806,10 @@
       "dev": true
     },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/@codemirror/view": {
-      "version": "6.2.2",
-      "resolved": "git+ssh://git@github.com/codemirror/view.git#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
-      "integrity": "sha512-ZimlXGCXKuaFar5MuKpbPJIL+jO7zz2vpt8zX1d+fGZccYju7Ot9pCSLw4y65uqTGv8zQI0hdD/bcDnBSGB0yw==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.2.4.tgz",
+      "integrity": "sha512-Zc5qDv+CD2ubWs6ShGJL0tf4y2w5vObdg7Eus0ouhg9g5lrvsAnwO9PvavDZdK4bpH6O+cnNDRhFlvDuieXo/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "style-mod": "^4.0.0",
@@ -35292,133 +35291,17 @@
       "dev": true
     },
     "node_modules/tracked-built-ins": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-2.0.1.tgz",
-      "integrity": "sha512-v0DwPVNm3zA4cmJLpcBJxJfKefN6ldhkc8l5YA+cWHq7kI8WMUcXjIXgl/AIxmt1SoO1bwPdpikPRHHrIBDtFQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-3.1.0.tgz",
+      "integrity": "sha512-yPEZV1aYaw7xFWdoEluvdwNxIJIA834HaBQaMATjNAYPwd1fRqIJ46YnuRo6+9mRRWu6nM6sJqrVVa5H6UhFuw==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.10",
-        "ember-cli-typescript": "^4.1.0",
-        "ember-tracked-storage-polyfill": "^1.0.0",
-        "tracked-maps-and-sets": "^3.0.2"
+        "ember-cli-typescript": "^5.1.0",
+        "ember-tracked-storage-polyfill": "^1.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
-      }
-    },
-    "node_modules/tracked-built-ins/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/tracked-built-ins/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tracked-built-ins/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/tracked-built-ins/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/tracked-built-ins/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tracked-built-ins/node_modules/tracked-maps-and-sets": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tracked-maps-and-sets/-/tracked-maps-and-sets-3.0.2.tgz",
-      "integrity": "sha512-UIRcWsX1kDOcC/Q2R58weYWlw01EnmWWBwUv3okWS+zMBvsgIfYoO6veHhuNE3hgzWCEImNp46QS5CyKnw5QUA==",
-      "dev": true,
-      "dependencies": {
-        "@glimmer/tracking": "^1.0.0",
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-typescript": "^4.2.1",
-        "ember-tracked-storage-polyfill": "1.0.0"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
-      }
-    },
-    "node_modules/tracked-built-ins/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/tracked-built-ins/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+        "node": "14.* || 16.* || >= 18.*"
       }
     },
     "node_modules/tracked-maps-and-sets": {
@@ -39650,15 +39533,14 @@
       }
     },
     "@lblod/ember-rdfa-editor": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.63.1.tgz",
-      "integrity": "sha512-s51CSJcdE0xlImI+PQsDBLSIyTpOJP3pE3yed5lfoT1+UkGtGFi2TtkRqUjzrCdlk/pHz/GG/X+nT1JgGeyLtw==",
+      "version": "git+ssh://git@github.com/lblod/ember-rdfa-editor.git#e5d71f58dbb684e73aed2cbe45c02973c2b5ee6f",
       "dev": true,
+      "from": "@lblod/ember-rdfa-editor@https://github.com/lblod/ember-rdfa-editor#fix/inline-components-management",
       "requires": {
         "@codemirror/lang-html": "^6.1.1",
         "@codemirror/lang-xml": "^6.0.0",
         "@codemirror/state": "^6.1.1",
-        "@codemirror/view": "github:codemirror/view#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
+        "@codemirror/view": "^6.2.3",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
         "@glimmer/tracking": "^1.0.4",
@@ -39691,7 +39573,7 @@
         "rdf-data-factory": "^1.1.0",
         "relative-to-absolute-iri": "^1.0.6",
         "stream-browserify": "^3.0.0",
-        "tracked-built-ins": "^2.0.1",
+        "tracked-built-ins": "^3.1.0",
         "xml-formatter": "^2.6.1"
       },
       "dependencies": {
@@ -39795,10 +39677,10 @@
           "dev": true
         },
         "@codemirror/view": {
-          "version": "git+ssh://git@github.com/codemirror/view.git#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
-          "integrity": "sha512-ZimlXGCXKuaFar5MuKpbPJIL+jO7zz2vpt8zX1d+fGZccYju7Ot9pCSLw4y65uqTGv8zQI0hdD/bcDnBSGB0yw==",
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.2.4.tgz",
+          "integrity": "sha512-Zc5qDv+CD2ubWs6ShGJL0tf4y2w5vObdg7Eus0ouhg9g5lrvsAnwO9PvavDZdK4bpH6O+cnNDRhFlvDuieXo/g==",
           "dev": true,
-          "from": "@codemirror/view@github:codemirror/view#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
           "requires": {
             "@codemirror/state": "^6.0.0",
             "style-mod": "^4.0.0",
@@ -65108,106 +64990,14 @@
       "dev": true
     },
     "tracked-built-ins": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-2.0.1.tgz",
-      "integrity": "sha512-v0DwPVNm3zA4cmJLpcBJxJfKefN6ldhkc8l5YA+cWHq7kI8WMUcXjIXgl/AIxmt1SoO1bwPdpikPRHHrIBDtFQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-3.1.0.tgz",
+      "integrity": "sha512-yPEZV1aYaw7xFWdoEluvdwNxIJIA834HaBQaMATjNAYPwd1fRqIJ46YnuRo6+9mRRWu6nM6sJqrVVa5H6UhFuw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.10",
-        "ember-cli-typescript": "^4.1.0",
-        "ember-tracked-storage-polyfill": "^1.0.0",
-        "tracked-maps-and-sets": "^3.0.2"
-      },
-      "dependencies": {
-        "ember-cli-typescript": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-          "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "tracked-maps-and-sets": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/tracked-maps-and-sets/-/tracked-maps-and-sets-3.0.2.tgz",
-          "integrity": "sha512-UIRcWsX1kDOcC/Q2R58weYWlw01EnmWWBwUv3okWS+zMBvsgIfYoO6veHhuNE3hgzWCEImNp46QS5CyKnw5QUA==",
-          "dev": true,
-          "requires": {
-            "@glimmer/tracking": "^1.0.0",
-            "ember-cli-babel": "^7.26.6",
-            "ember-cli-typescript": "^4.2.1",
-            "ember-tracked-storage-polyfill": "1.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "ember-cli-typescript": "^5.1.0",
+        "ember-tracked-storage-polyfill": "^1.0.0"
       }
     },
     "tracked-maps-and-sets": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@ember/test-helpers": "^2.6.0",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
-        "@lblod/ember-rdfa-editor": "github:lblod/ember-rdfa-editor#fix/inline-components-management",
+        "@lblod/ember-rdfa-editor": ">=0.63.3",
         "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.2.9",
         "@types/ember": "^4.0.0",
         "@types/ember__application": "^4.0.0",
@@ -95,7 +95,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^1.5.0",
-        "@lblod/ember-rdfa-editor": ">=0.63.1",
+        "@lblod/ember-rdfa-editor": ">=0.63.3",
         "ember-concurrency": "^2.0.0"
       }
     },
@@ -3626,10 +3626,10 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "0.63.2",
-      "resolved": "git+ssh://git@github.com/lblod/ember-rdfa-editor.git#e5d71f58dbb684e73aed2cbe45c02973c2b5ee6f",
+      "version": "0.63.3",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.63.3.tgz",
+      "integrity": "sha512-BB5S7fjwxi/TH2t5EIG+5KZiwsnrsY4815nQCBQbZy5Z3bXa6DpqsQp/SiWB6Dxefyhm61cgRmmXAOKun1NHjA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",
         "@codemirror/lang-xml": "^6.0.0",
@@ -39533,9 +39533,10 @@
       }
     },
     "@lblod/ember-rdfa-editor": {
-      "version": "git+ssh://git@github.com/lblod/ember-rdfa-editor.git#e5d71f58dbb684e73aed2cbe45c02973c2b5ee6f",
+      "version": "0.63.3",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.63.3.tgz",
+      "integrity": "sha512-BB5S7fjwxi/TH2t5EIG+5KZiwsnrsY4815nQCBQbZy5Z3bXa6DpqsQp/SiWB6Dxefyhm61cgRmmXAOKun1NHjA==",
       "dev": true,
-      "from": "@lblod/ember-rdfa-editor@https://github.com/lblod/ember-rdfa-editor#fix/inline-components-management",
       "requires": {
         "@codemirror/lang-html": "^6.1.1",
         "@codemirror/lang-xml": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@lblod/ember-rdfa-editor": ">=0.63.1",
+    "@lblod/ember-rdfa-editor": "github:lblod/ember-rdfa-editor#fix/inline-components-management",
     "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.2.9",
     "@types/ember": "^4.0.0",
     "@types/ember__application": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^1.5.0",
-    "@lblod/ember-rdfa-editor": ">=0.63.1",
+    "@lblod/ember-rdfa-editor": ">=0.63.3",
     "ember-concurrency": "^2.0.0"
   },
   "devDependencies": {
@@ -49,7 +49,7 @@
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@lblod/ember-rdfa-editor": "github:lblod/ember-rdfa-editor#fix/inline-components-management",
+    "@lblod/ember-rdfa-editor": ">=0.63.3",
     "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.2.9",
     "@types/ember": "^4.0.0",
     "@types/ember__application": "^4.0.0",


### PR DESCRIPTION
This PR includes a modification on how the `toggled` property of the `table-of-contents-card` component works. The `toggled` property is now updated whenever a `modelWritten` event occurs or whenever it is interacted with. To be used in conjunction with https://github.com/lblod/ember-rdfa-editor/pull/363.