### PR TITLE
Update inline component according to new properties API

### DIFF
--- a/addon/components/inline-components/table-of-contents.js
+++ b/addon/components/inline-components/table-of-contents.js
@@ -21,9 +21,9 @@ export default class TableOfContentsComponent extends Component {
   }
 
   get config() {
-    return this.args.componentController.props.config
-      ? this.args.componentController.props.config
-      : DEFAULT_CONFIG;
+    return (
+      this.args.componentController.getProperty('config') ?? DEFAULT_CONFIG
+    );
   }
 
   willDestroy() {

--- a/addon/components/table-of-contents-card.js
+++ b/addon/components/table-of-contents-card.js
@@ -40,7 +40,6 @@ export default class TableOfContentsCardComponent extends Component {
         'insert-component',
         'inline-components/table-of-contents',
         this.tableOfContentsProps,
-        {},
         false,
         this.args.controller.rangeFactory.fromInElement(
           this.args.controller.modelRoot,

--- a/addon/models/inline-components/table-of-contents.js
+++ b/addon/models/inline-components/table-of-contents.js
@@ -1,13 +1,15 @@
 import { InlineComponentSpec } from '@lblod/ember-rdfa-editor/model/inline-components/model-inline-component';
 import { isElement } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+import { DEFAULT_CONFIG } from '@lblod/ember-rdfa-editor-table-of-contents-plugin/utils/default_config';
 export default class TableOfContentsSpec extends InlineComponentSpec {
   matcher = {
     tag: this.tag,
     attributeBuilder: (node) => {
       if (isElement(node)) {
         if (
-          node.classList.contains('inline-component') &&
-          node.classList.contains(this.name)
+          (node.classList.contains('inline-component') &&
+            node.classList.contains(this.name)) ||
+          node.dataset.inlineComponent === this.name
         ) {
           return {};
         }
@@ -15,6 +17,11 @@ export default class TableOfContentsSpec extends InlineComponentSpec {
       return null;
     },
   };
+
+  properties = {
+    config: { serializable: true, defaultValue: DEFAULT_CONFIG },
+  };
+
   _renderStatic() {
     // TODO: should be implemented when static version of inline components work correctly
     return '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@ember/test-helpers": "^2.6.0",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
-        "@lblod/ember-rdfa-editor": ">=0.63.3",
+        "@lblod/ember-rdfa-editor": ">=0.64.0",
         "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.2.9",
         "@release-it-plugins/lerna-changelog": "^5.0.0",
         "@types/ember": "^4.0.0",
@@ -3634,9 +3634,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "0.63.3",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.63.3.tgz",
-      "integrity": "sha512-BB5S7fjwxi/TH2t5EIG+5KZiwsnrsY4815nQCBQbZy5Z3bXa6DpqsQp/SiWB6Dxefyhm61cgRmmXAOKun1NHjA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.64.0.tgz",
+      "integrity": "sha512-WgADVsG9icjQyTn396GO1G73ikwuboi9yClqCtPL7fpZmYiUy8Vq3Xp3DFHmwQaqdSXcCXkbg78sxuKehdad/Q==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",
@@ -42993,9 +42993,9 @@
       }
     },
     "@lblod/ember-rdfa-editor": {
-      "version": "0.63.3",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.63.3.tgz",
-      "integrity": "sha512-BB5S7fjwxi/TH2t5EIG+5KZiwsnrsY4815nQCBQbZy5Z3bXa6DpqsQp/SiWB6Dxefyhm61cgRmmXAOKun1NHjA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.64.0.tgz",
+      "integrity": "sha512-WgADVsG9icjQyTn396GO1G73ikwuboi9yClqCtPL7fpZmYiUy8Vq3Xp3DFHmwQaqdSXcCXkbg78sxuKehdad/Q==",
       "dev": true,
       "requires": {
         "@codemirror/lang-html": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@lblod/ember-rdfa-editor": ">=0.63.3",
+    "@lblod/ember-rdfa-editor": ">=0.64.0",
     "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.2.9",
     "@release-it-plugins/lerna-changelog": "^5.0.0",
     "@types/ember": "^4.0.0",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -30,7 +30,6 @@ export default class ApplicationController extends Controller {
       {
         config: this.tableOfContentsConfig,
       },
-      {},
       false
     );
     controller.executeCommand(


### PR DESCRIPTION
This updates the table of contents inline components so that it conforms to the changed API introduced in https://github.com/lblod/ember-rdfa-editor/pull/455.